### PR TITLE
Ea/765 biotype

### DIFF
--- a/tark-refseq-loader/handlers/refseq/annotationhandler.py
+++ b/tark-refseq-loader/handlers/refseq/annotationhandler.py
@@ -47,7 +47,11 @@ class AnnotationHandler(object):
         if hgnc_id is not None:
             hgnc_id = "HGNC:" + hgnc_id
         gene['hgnc_id'] = hgnc_id
-
+        # populate biotype for gene
+        if 'gene_biotype' in gene_feature.qualifiers:
+            gene['biotype'] = gene_feature.qualifiers['gene_biotype'][0]
+        else:
+            gene['biotype'] = None
         gene['session_id'] = None
         gene['loc_checksum'] = ChecksumHandler.get_location_checksum(gene)
         gene['gene_checksum'] = ChecksumHandler.get_gene_checksum(gene)
@@ -67,6 +71,17 @@ class AnnotationHandler(object):
         (transcript_stable_id, transcript_stable_id_version) = stable_id.split(".")
         transcript['stable_id'] = transcript_stable_id
         transcript['stable_id_version'] = transcript_stable_id_version
+        # populate biotype for transcript
+        if transcript_stable_id[0:3] == "NM_":
+            transcript['biotype'] = "protein_coding"
+        elif transcript_stable_id[0:3] == "NR_":
+            transcript['biotype'] = "non_protein_coding"
+        elif transcript_stable_id[0:3] == "XM_":
+            transcript['biotype'] = "predicted_protein_coding"
+        elif transcript_stable_id[0:3] == "XR_":
+            transcript['biotype'] = "predicted_non_protein_coding"
+        else:
+            transcript['biotype'] = None       
         transcript['session_id'] = None
         transcript['transcript_checksum'] = None
         transcript['exon_set_checksum'] = None

--- a/tark-refseq-loader/handlers/refseq/databasehandler.py
+++ b/tark-refseq-loader/handlers/refseq/databasehandler.py
@@ -248,12 +248,12 @@ class FeatureHandler(SessionHandler, ReleaseHandler, ReleaseSourceHandler, Genom
         gene_data = {k: v for (k, v) in gene.items() if k not in ["transcripts"]}
         gene_data["session_id"] = self.session_id
         gene_data["assembly_id"] = self.assembly_id
-
-        insert_gene = ("INSERT INTO gene (stable_id, stable_id_version, assembly_id, \
+        # populate biotype for gene
+        insert_gene = ("INSERT INTO gene (stable_id, stable_id_version, biotype, assembly_id, \
                         loc_region, loc_start, loc_end, loc_strand, loc_checksum, \
                         name_id, gene_checksum, session_id) \
                         VALUES (\
-                        %(stable_id)s, %(stable_id_version)s,  %(assembly_id)s, \
+                        %(stable_id)s, %(stable_id_version)s,  %(biotype)s,  %(assembly_id)s, \
                         %(loc_region)s, %(loc_start)s,  %(loc_end)s,  %(loc_strand)s,  X%(loc_checksum)s, \
                         %(hgnc_id)s,  X%(gene_checksum)s,  %(session_id)s) \
                         ON DUPLICATE KEY UPDATE gene_id=LAST_INSERT_ID(gene_id)")
@@ -265,13 +265,13 @@ class FeatureHandler(SessionHandler, ReleaseHandler, ReleaseSourceHandler, Genom
         return gene_id
 
     def add_transcripts(self, transcripts, gene_id):
-
-        insert_transcript = ("INSERT INTO transcript (stable_id, stable_id_version, assembly_id, \
+        # populate biotype for transcript
+        insert_transcript = ("INSERT INTO transcript (stable_id, stable_id_version, biotype, assembly_id, \
                             loc_region, loc_start, loc_end, loc_strand, loc_checksum, \
                             transcript_checksum, \
                             exon_set_checksum, seq_checksum, session_id) \
                             VALUES (\
-                            %(stable_id)s, %(stable_id_version)s, %(assembly_id)s, \
+                            %(stable_id)s, %(stable_id_version)s,  %(biotype)s, %(assembly_id)s, \
                             %(loc_region)s, %(loc_start)s, %(loc_end)s, %(loc_strand)s, X%(loc_checksum)s, \
                             X%(transcript_checksum)s, \
                             X%(exon_set_checksum)s, X%(seq_checksum)s, %(session_id)s) \


### PR DESCRIPTION
This PR 5 covers [EA-765](https://www.ebi.ac.uk/panda/jira/browse/EA-765) 
Biotype work: Update the RefSeq loader script to populate biotype for transcript and gene.

Note: [Link to fetch biotype from Accession prefix](https://www.ncbi.nlm.nih.gov/books/NBK21091/table/ch18.T.refseq_accession_numbers_and_mole/?report=objectonly)

Refer [confluence_page ](https://www.ebi.ac.uk/seqdb/confluence/display/EA/One+time+script+to+load+Biotype+in+gene+and+transcript+table) for scripts

The [Tark PR 28](https://github.com/Ensembl/tark/pull/28) covers following tickets
ea-644 - Display gene count in release stats
ea-766 - update tark UI to display biotype in gene & transcript
ea- 774 - add biotype to transcript details