### PR TITLE
Ea/780 utr checksum

### DIFF
--- a/tark-refseq-loader/scripts/parse_gff_file.py
+++ b/tark-refseq-loader/scripts/parse_gff_file.py
@@ -153,7 +153,13 @@ class ParseRecord(luigi.Task):
                     print("About to load gene => " + str(annotated_gene['stable_id']))
                     feature_handler = FeatureHandler(parent_ids=self.parent_ids, dbc=dbc)
                     feature_handler.save_features_to_database(feature_object_to_save)
-
+                  
+        # call update_utr_checksum() in databasehandler.py, to update UTR checksum in translation table          
+        if not self.dryrun:
+            print("About to update 5' and 3' UTR checksum in translation table")
+            feature_utr_checksum_handler = FeatureHandler(dbc=dbc)
+            feature_utr_checksum_handler.update_utr_checksum()
+            
         dbc.close()
         gff_handle.close()
 


### PR DESCRIPTION
EA-807
Refseq loader script for updating 5' and 3' UTR checksum columns in translation table
for one-time loading of UTR checksum script: [refer confluence page](https://www.ebi.ac.uk/seqdb/confluence/display/EA/One+time+script+to+load+5%27+and+3%27+UTR+checksum+in+translation+table)
dev: https://dev-tark.ensembl.org/web/mane_GRCh37_list/
db: